### PR TITLE
upgrading dredd version to 4.7.0 so that we can run the dredd tests a…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM node:7.0
 MAINTAINER Foundation DevOps foundation-devops@realpage.com
-LABEL com.realpage.dredd.version="2.2.3"
+LABEL com.realpage.dredd.version="4.7.0"
 
-RUN npm install -g dredd@2.2.3
+RUN npm install -g dredd@4.7.0
 
 # Allow dredd to see items in the vendor path 
 ENV PATH /var/www/html/vendor/bin:$PATH

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # RealPage Official Docker Image for Dredd [![Build Status](https://travis-ci.org/realpage/dredd.svg?branch=master)](https://travis-ci.org/realpage/dredd)
 
 ## Supported tags
-- [`2.2.3`, `2.2`, `2`, `latest` (*Dockerfile*)](https://github.com/realpage/dredd/blob/master/Dockerfile)
+- [`4.7.0` `2.2.3`, `2.2`, `2`, `latest` (*Dockerfile*)](https://github.com/realpage/dredd/blob/master/Dockerfile)
 
 ## Issues
 If you have any problems with or questions about this image, please contact us through a [GitHub issue](https://github.com/realpage/dredd/issues).

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 repository="realpage/dredd"
-tags=( "2.2.3" "2.2" "2" )
+tags=( "4.7.0" "2.2.3" "2.2" "2" )
 tagscli=
 
 echo "Building tags for images"


### PR DESCRIPTION
…gainst swagger documentation